### PR TITLE
CacheTagsChecksum-based invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-09-13
+### Changed
+- **BC** Use CacheTagChecksum to invalidate cache tags. See https://github.com/wieni/wmcontroller_redis/pull/4
+  - Upgrade steps:
+    - Add `wmcontroller.cache.invalidator: wmcontroller.redis.checksum` to your `services.yml` file.
+    - Run `drush wmcontroller_redis:mark-expired` nightly to search for stale entries and mark them for deletion
+
 ## [1.1.0] - 2023-09-13
 ### Added
 - Add Drupal 10 compatibility

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ $settings['wmcontroller.redis.connection']['host'] = '127.0.0.1';
 $settings['wmcontroller.redis.connection']['base'] = '0';
 ```
 
+Run `drush wmcontroller_redis:mark-expired` nightly to search for stale entries
+and mark them for deletion.
+
 ## Changelog
 All notable changes to this project will be documented in the
 [CHANGELOG](CHANGELOG.md) file.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ installed using Composer:
  composer require wieni/wmcontroller_redis
 ```
 
-To enable this cache storage, change the `wmcontroller.cache.storage` container parameter:
+To enable this cache storage, change the `wmcontroller.cache.storage` and `wmcontroller.cache.invalidator` container parameter:
 ```yaml
 parameters:
     wmcontroller.cache.storage: wmcontroller.cache.storage.redis
+    wmcontroller.cache.invalidator: wmcontroller.redis.checksum
 
     wmcontroller.cache.redis.prefix: 'wmcontroller:'
 ```

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,0 +1,5 @@
+services:
+    wmcontroller_redis.commands.cache:
+        class: Drupal\wmcontroller_redis\Commands\CacheCommands
+        arguments: ['@wmcontroller.cache.storage']
+        tags: [{ name: drush.command }]

--- a/src/Cache/CacheTagsChecksum.php
+++ b/src/Cache/CacheTagsChecksum.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\wmcontroller_redis\Cache;
+
+use Drupal\Core\Cache\CacheTagsChecksumInterface;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\redis\Cache\RedisCacheTagsChecksum;
+use Drupal\wmcontroller\Service\Cache\InvalidatorInterface;
+use Drupal\wmcontroller_redis\RedisClientFactory;
+
+class CacheTagsChecksum implements CacheTagsChecksumInterface, CacheTagsInvalidatorInterface, InvalidatorInterface
+{
+    /** @var \Drupal\wmcontroller_redis\RedisClientFactory */
+    protected $redisClientFactory;
+
+    /** @var CacheTagsChecksumInterface|CacheTagsInvalidatorInterface|false */
+    private $redisCacheTagsChecksum;
+
+    public function __construct(RedisClientFactory $redisClientFactory)
+    {
+        $this->redisClientFactory = $redisClientFactory;
+    }
+
+    public function getCurrentChecksum(array $tags)
+    {
+        if ($decorated = $this->decorated()) {
+            return $decorated->getCurrentChecksum($tags);
+        }
+        return 'noop';
+    }
+
+    public function isValid($checksum, array $tags)
+    {
+        if ($decorated = $this->decorated()) {
+            return $decorated->isValid($checksum, $tags);
+        }
+        return false;
+    }
+
+    public function reset()
+    {
+        if ($decorated = $this->decorated()) {
+            $decorated->reset();
+        }
+    }
+
+    public function invalidateCacheTags(array $tags)
+    {
+        // noop
+        // We use Drupal's cache tag invalidation system to invalidate the cache
+    }
+
+    public function invalidateTags(array $tags)
+    {
+        if ($decorated = $this->decorated()) {
+            $decorated->invalidateTags($tags);
+        }
+    }
+
+    /** @return CacheTagsChecksumInterface|CacheTagsInvalidatorInterface|null */
+    protected function decorated()
+    {
+        if (isset($this->redisCacheTagsChecksum)) {
+            return $this->redisCacheTagsChecksum ?: null;
+        }
+
+        $decorated = false;
+        try {
+            $client = $this->redisClientFactory::getClient();
+            if ($client instanceof \Redis) {
+                $decorated = new RedisCacheTagsChecksum($this->redisClientFactory);
+            }
+        } catch (\Exception $e) {
+            watchdog_exception('wmcontroller.redis', $e);
+        }
+
+        return $this->redisCacheTagsChecksum = $decorated;
+    }
+}

--- a/src/Commands/CacheCommands.php
+++ b/src/Commands/CacheCommands.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\wmcontroller_redis\Commands;
+
+use Drupal\wmcontroller\Service\Cache\Storage\StorageInterface;
+use Drupal\wmcontroller_redis\Storage\MarksExpiredInterface;
+use Drush\Commands\DrushCommands;
+
+class CacheCommands extends DrushCommands
+{
+
+    /** @var \Drupal\wmcontroller\Service\Cache\Storage\StorageInterface */
+    protected $storage;
+
+    public function __construct(StorageInterface $storage)
+    {
+        parent::__construct();
+        $this->storage = $storage;
+    }
+
+    /**
+     * Look for stale cache entries and mark them.
+     *
+     * @command wmcontroller_redis:mark-expired
+     */
+    public function markExpired()
+    {
+        if (!$this->storage instanceof MarksExpiredInterface) {
+            throw new \RuntimeException('Storage does not support marking stale entries');
+        }
+
+        $count = $this->storage->markExpired();
+        if ($this->logger()) {
+            $this->logger()->notice("Marked $count stale entries for deletion.");
+        }
+    }
+
+}

--- a/src/RedisChecksumClientFactory.php
+++ b/src/RedisChecksumClientFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\wmcontroller_redis;
+
+/**
+ * We extend it because we want a different client
+ * The ClientFactory calls static::$client so we cannot re-use the same
+ * factory. This sucks
+ */
+class RedisChecksumClientFactory extends RedisClientFactory
+{
+    protected static $client;
+}

--- a/src/Storage/MarksExpiredInterface.php
+++ b/src/Storage/MarksExpiredInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\wmcontroller_redis\Storage;
+
+interface MarksExpiredInterface
+{
+
+    /**
+     * Search for stale entries and mark them as expired. This should be run
+     * periodically (nightly).
+     *
+     * @return int The number of stale entries found
+     */
+    public function markExpired();
+
+}

--- a/wmcontroller_redis.services.yml
+++ b/wmcontroller_redis.services.yml
@@ -5,14 +5,24 @@ services:
     wmcontroller.redis.factory:
         class: Drupal\wmcontroller_redis\RedisClientFactory
 
+    wmcontroller.redis.factory.checksum:
+        class: Drupal\wmcontroller_redis\RedisChecksumClientFactory
+
     wmcontroller.redis.internal.serializer:
         class: Drupal\wmcontroller_redis\Serializer
         arguments:
             - '@wmcontroller.cache.serializer'
+
+    wmcontroller.redis.checksum:
+        class: Drupal\wmcontroller_redis\Cache\CacheTagsChecksum
+        arguments: ['@wmcontroller.redis.factory.checksum']
+        tags:
+            - { name: cache_tags_invalidator }
 
     wmcontroller.cache.storage.redis:
         class: Drupal\wmcontroller_redis\Storage\RedisStorage
         arguments:
             - '@wmcontroller.redis.factory'
             - '@wmcontroller.redis.internal.serializer'
+            - '@wmcontroller.redis.checksum'
             - '%wmcontroller.cache.redis.prefix%'


### PR DESCRIPTION
## Description

Currently each time a cachetag is invalidated, the default implementation [`wmcontroller::invalidateCacheTags()` calls](https://github.com/wieni/wmcontroller/blob/1.2.0/src/Service/Cache/Invalidator.php#L19-L21) the [`RedisStorage::getByTags()`](https://github.com/wieni/wmcontroller_redis/blob/1.1.0/src/Storage/RedisStorage.php#L119-L140) to know which entries need to be removed.

When a popular cachetag (a footer item displayed on every page) is invalidated, Redis answers with a huge set of entries.
This causes problems on big projects. Whenever a popular node is saved, the CMS hangs while we try to remove the thousands of entries.

This PR offers a new `wmcontroller.redis.checksum` invalidator implementation that uses Drupal's CacheTagsChecksum.
Whenever we store a new cache entry, we also store the CacheTagsChecksum integer of the entry's cachetags.

When we load a cached entry, before we return the entry, we validate the checksum of entry's cachetags again.
If the checksum doesn't match with what we had stored, it means one of the cachetags received an invalidation and we throw a `NoSuchCacheEntryException`.

Using this method, we no longer do the expensive lookup-and-remove-entries each time a cachetag is invalidated.
**But**, this also means stale entries are kept indefinitely or until the next `cache_clear`.
I'm not 100% certain, but I believe Drupal Core has this problem too.

This PR also provides a drush command `wmcontroller_redis:mark-expired` you can call. It will loop over all cached entries and verify their checksums. If a checksum isn't valid it will mark the entry as expired. During the next cron run  `wmcontroller_cron_purge_expired` will remove the expired entries.
The drush command is tested against a project with more than 280K cache entries and finishes under 10 seconds.

### Caveat

Drupal's `CacheTagsChecksumInterface` keeps a static cache of all the cachetags it verifies. This causes it to slow down the more checks it does.
We circumvent this by periodically calling its `->reset()` method. However this might cause problems because that static cache is also used to track which tags have been invalidated during the request, to prevent the invalidation of the same cache tag multiple times.

That's why I decided to turn this in a `drush` command instead of a cron hook.
So you can call this in a separate Drush process where no invalidations take place.

## Upgrade

To upgrade to `2.0.0` you will need to perform two actions:

### Use the `wmcontroller.redis.checksum` checksum invalidator

In your `services.yml` file add the folowing parameter:

```diff
parameters:
    wmcontroller.cache.storage: wmcontroller.cache.storage.redis
+   wmcontroller.cache.invalidator: wmcontroller.redis.checksum
```

### Run the `wmcontroller_redis:mark-expired` drush command every night

This will mark stale entries as expired so it will be removed by `wmcontroller` in the next cron run.
It's best to run this in a separate `drush` process once per night. See [RedisStorage.php#L229-L240](https://github.com/wieni/wmcontroller_redis/blob/2.0.0/src/Storage/RedisStorage.php#L229-L240) for more information.
Don't try to run this from `HOOK_cron`.