### PR TITLE
#6 Fix ArgumentCountError for Redis::sAdd() in RedisStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2023-10-16
+### Fixed
+- Fix ArgumentCountError: Wrong parameter count for Redis::sAdd() in RedisStorage.php. See https://github.com/wieni/wmcontroller_redis/pull/7
+
 ## [2.0.0] - 2023-09-13
 ### Changed
 - **BC** Use CacheTagChecksum to invalidate cache tags. See https://github.com/wieni/wmcontroller_redis/pull/4

--- a/src/Storage/RedisStorage.php
+++ b/src/Storage/RedisStorage.php
@@ -122,18 +122,22 @@ class RedisStorage implements StorageInterface, MarksExpiredInterface
             $item->getExpiry(),
             $id
         );
-        $tx->del($this->prefix($id, 'tags'));
-        $tx->sAdd(
-            $this->prefix($id, 'tags'),
-            ...$tags
-        );
         $tx->sRem($this->prefix('stale'), $id);
-        foreach ($tags as $tag) {
+
+        $tx->del($this->prefix($id, 'tags'));
+        if (!empty($tags)) {
             $tx->sAdd(
-                $this->prefix($tag),
-                $id
+                $this->prefix($id, 'tags'),
+                ...$tags
             );
+            foreach ($tags as $tag) {
+                $tx->sAdd(
+                    $this->prefix($tag),
+                    $id
+                );
+            }
         }
+
         $path = parse_url($item->getUri(), PHP_URL_PATH);
         if ($path) {
             $tx->set(


### PR DESCRIPTION
When `RedisStorage::set(Cache $item, array $tags)` is called with an empty `$tags` array we get an `ArgumentCountError` error. This only happens on [`phpredis >= 6.0.0`](https://github.com/phpredis/phpredis/tags)

We fix this by wrapping the relevant [sAdd() method](https://github.com/wieni/wmcontroller_redis/blob/f355e7eea6ad919d02324d7c4fb49cb0e639bea6/src/Storage/RedisStorage.php#L126-L129) in an if-block



